### PR TITLE
Adds hostnames for WireGuard protocol and fixes sorting in Chrome

### DIFF
--- a/src/themes/ivpn-v3/assets/js/components/ServerList.vue
+++ b/src/themes/ivpn-v3/assets/js/components/ServerList.vue
@@ -3,7 +3,7 @@
         <thead>
             <tr>
                 <th class="location">LOCATION</th>
-                <th>SERVER</th>
+                <th class="hostnames">HOSTNAMES</th>
                 <th class="load">LOAD</th>
                 <th class="provider">PROVIDER</th>
                 <th class="wg_public_key">WIREGUARD PUBLIC KEY</th>
@@ -12,28 +12,33 @@
         <tbody>
             <tr v-for="server in sortedList">
                 <td class="location">
-                    <i
-                        class="flag-icon"
-                        :class="
-                            'flag-icon-' + server.country_code.toLowerCase()
-                        "
-                    ></i>
-                    <strong>{{ server.country }}</strong>
-                    <div>
-                        <span
-                            v-for="protocol in server.protocols"
-                            class="badge badge--light spacing"
-                            >{{ renderProtocolName(protocol) }}</span
-                        >
+                    <div class="location__data">
+                        <i
+                            class="flag-icon"
+                            :class="
+                                'flag-icon-' + server.country_code.toLowerCase()
+                            "
+                        ></i>
+                        <span> {{ server.country }}, {{ server.city }} </span>
                     </div>
                 </td>
-                <td>
-                    <em>Server</em>
-                    <i
-                        class="status"
-                        :class="{ 'status--active': server.is_active }"
-                    ></i
-                    >{{ server.gateway }}
+                <td class="hostnames">
+                    <em>Hostnames</em>
+                    <ul>
+                        <li
+                            v-for="(host, protocol) in server.hostnames"
+                            :key="protocol"
+                        >
+                            <i
+                                class="status"
+                                :class="{ 'status--active': server.is_active }"
+                            ></i
+                            >{{ host }}
+                            <span class="badge badge--light spacing">{{
+                                protocol
+                            }}</span>
+                        </li>
+                    </ul>
                 </td>
                 <td class="load">
                     <em>Load</em>
@@ -86,7 +91,13 @@ export default {
     },
     computed: {
         sortedList: function () {
-            return this.servers.sort((a, b) => a.gateway > b.gateway);
+            return this.servers.sort((a, b) => {
+                if (a.gateway > b.gateway) {
+                    return 1
+                } else if (a.gateway < b.gateway)
+                    return -1
+                return 0
+            });
         },
     },
 };
@@ -107,22 +118,30 @@ export default {
     border-radius: 50%;
     vertical-align: middle;
 
-    @include light-theme((
-        background: $light-mode-yellow-color
-    ));
+    @include light-theme(
+        (
+            background: $light-mode-yellow-color,
+        )
+    );
 
-    @include dark-theme((
-        background: $dark-mode-yellow-color
-    ));
+    @include dark-theme(
+        (
+            background: $dark-mode-yellow-color,
+        )
+    );
 
     &--active {
-        @include light-theme((
-            background: $light-mode-green-color
-        ));
+        @include light-theme(
+            (
+                background: $light-mode-green-color,
+            )
+        );
 
-        @include dark-theme((
-            background: $dark-mode-green-color
-        ));
+        @include dark-theme(
+            (
+                background: $dark-mode-green-color,
+            )
+        );
     }
 }
 </style>

--- a/src/themes/ivpn-v3/assets/scss/components/servers.scss
+++ b/src/themes/ivpn-v3/assets/scss/components/servers.scss
@@ -33,6 +33,9 @@
     
                 td {
 
+                    &.location {
+                        padding: 8px 0px;
+                    }
 
                     &.load {
                         
@@ -73,7 +76,7 @@
             ));
 
             &.location {
-                width: 23%;
+                width: 22%;
             }
 
             &.load {
@@ -86,7 +89,7 @@
             }
 
             &.wg_public_key {
-                width: 24%;
+                width: 18%;
             }
         }
 
@@ -108,13 +111,28 @@
             }
 
             &.location {
+                .location__data {
+                    display: flex;            
+                    align-items: baseline;
+                }
+                
+                font-weight: bold;
+                line-height: 24px;
+                
 
                 i {
+                    min-width: 24px;
                     border-radius: 2px;
+                    margin-right: 16px;
                 }
 
                 div {
                     padding-top: 2px;
+                }
+            }
+            &.hostnames {
+                ul {
+                    padding-left: 8px;
                 }
             }
 


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [ ] I have read the CONTRIBUTING.md doc
- [ ] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

Server status page doesn't show proper hostnames which should be used for WireGuard protocol.

## What is the new behavior?

Near each server separate hostnames for OpenVPN and WireGuard are shown

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
