### PR TITLE
Disable taxonomy listing pages

### DIFF
--- a/src/config/_default/config.toml
+++ b/src/config/_default/config.toml
@@ -4,7 +4,7 @@ title = "IVPN"
 theme = "ivpn-v3"
 paginate = 8
 summaryLength = 35
-disableKinds = ["sitemap"]
+disableKinds = ["sitemap", "taxonomyTerm"]
 
 [markup.goldmark.renderer]
     unsafe= true


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

By default, Hugo generates unused listing pages for all taxonomies.

## What is the new behavior?

Listing pages `/tags/`, `/categories/` and `/authors/` are now disabled (404).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No