### PR TITLE
Stops recording "account created" events, when changing product

### DIFF
--- a/src/themes/ivpn-v3/assets/js/views/Prices.vue
+++ b/src/themes/ivpn-v3/assets/js/views/Prices.vue
@@ -124,8 +124,12 @@ export default {
                 }
             }
         
+            let wasAuthenticated = this.auth.isAuthenticated
+
             await this.$store.dispatch("auth/createAccount", { product });
-            matomo.recordAccountCreated();
+            if (!wasAuthenticated) {
+                matomo.recordAccountCreated();
+            }
             this.$router.push({ name: "account" });
         },
     },


### PR DESCRIPTION
## PR type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When user change product after creating new account, each of this product changes is recorded as a new account created in matomo. 

## What is the new behavior?

Account created event is triggered only once

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
