### PR TITLE
Adds "suggest an edit" footer section for content pages

### DIFF
--- a/src/themes/ivpn-v3/assets/scss/components/suggest-an-edit.scss
+++ b/src/themes/ivpn-v3/assets/scss/components/suggest-an-edit.scss
@@ -1,0 +1,18 @@
+.suggest-an-edit {
+    line-height: 1.5; 
+    padding: 1em; 
+    font-size: 12px; 
+    text-align: center;
+
+    a {
+        font-weight: bold;
+    }
+
+    @include light-theme((
+        background: $light-mode-alternative-background
+    ));
+
+    @include dark-theme((
+        background: $light-mode-text
+    ));
+}

--- a/src/themes/ivpn-v3/assets/scss/pages.scss
+++ b/src/themes/ivpn-v3/assets/scss/pages.scss
@@ -33,6 +33,7 @@
 @import "components/cta";
 @import "components/buttons";
 
+@import "components/suggest-an-edit";
 @import "components/stances";
 @import "components/blog";
 @import "components/badge";

--- a/src/themes/ivpn-v3/layouts/blog/single.html
+++ b/src/themes/ivpn-v3/layouts/blog/single.html
@@ -121,4 +121,6 @@
     </section>
 {{ end }}
 
+{{- partial "suggest-an-edit.html" . -}}
+
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/apps-single.html
+++ b/src/themes/ivpn-v3/layouts/pages/apps-single.html
@@ -34,4 +34,7 @@
         {{ .Content | markdownify }}
     </div>
 </section>
+
+{{- partial "suggest-an-edit.html" . -}}
+
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/apps.html
+++ b/src/themes/ivpn-v3/layouts/pages/apps.html
@@ -64,4 +64,7 @@
         {{ .Content | markdownify }}
     </div>
 </section>
+
+{{- partial "suggest-an-edit.html" . -}}
+
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/guides-details.html
+++ b/src/themes/ivpn-v3/layouts/pages/guides-details.html
@@ -14,4 +14,7 @@
         {{- partial "more-info.html" . -}}
     </div>
 </section>
+
+{{- partial "suggest-an-edit.html" . -}}
+
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/guides.html
+++ b/src/themes/ivpn-v3/layouts/pages/guides.html
@@ -31,4 +31,7 @@
         </section>
     </div>
 </section>
+
+{{- partial "suggest-an-edit.html" . -}}
+
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/help-details.html
+++ b/src/themes/ivpn-v3/layouts/pages/help-details.html
@@ -46,4 +46,5 @@
     </div>
 </section>
 <script src="{{ site.Params.cdnUrl }}{{ index $.Site.Data.manifest "/js/search.js" }}"></script>
+{{- partial "suggest-an-edit.html" . -}}
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/setup-article.html
+++ b/src/themes/ivpn-v3/layouts/pages/setup-article.html
@@ -16,4 +16,5 @@
         </div>
     </div>
 </section>
+{{- partial "suggest-an-edit.html" . -}}
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/setup-list.html
+++ b/src/themes/ivpn-v3/layouts/pages/setup-list.html
@@ -15,4 +15,5 @@
         </div>
     </div>
 </section>
+{{- partial "suggest-an-edit.html" . -}}
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/setup.html
+++ b/src/themes/ivpn-v3/layouts/pages/setup.html
@@ -5,4 +5,5 @@
         {{ .Content | markdownify }}
     </div>
 </section>
+{{- partial "suggest-an-edit.html" . -}}
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/pages/single.html
+++ b/src/themes/ivpn-v3/layouts/pages/single.html
@@ -11,4 +11,5 @@
             </div>
         </section>
     {{ end }}
+    {{- partial "suggest-an-edit.html" . -}}
 {{ end }}

--- a/src/themes/ivpn-v3/layouts/partials/suggest-an-edit.html
+++ b/src/themes/ivpn-v3/layouts/partials/suggest-an-edit.html
@@ -1,0 +1,4 @@
+<div class='suggest-edit' style='line-height: 1.5; padding: 1em; font-size: 12px; text-align:right;'>
+    Spot a mistake or know how to make this page better? <br/>
+    <a href='https://github.com/ivpn/ivpn.net/tree/main/src/content/{{ .File.Path }}' target="_blank">Suggest an edit</a> to this page on GitHub.
+</div>

--- a/src/themes/ivpn-v3/layouts/partials/suggest-an-edit.html
+++ b/src/themes/ivpn-v3/layouts/partials/suggest-an-edit.html
@@ -1,4 +1,5 @@
-<div class='suggest-edit' style='line-height: 1.5; padding: 1em; font-size: 12px; text-align:right;'>
-    Spot a mistake or know how to make this page better? <br/>
-    <a href='https://github.com/ivpn/ivpn.net/tree/main/src/content/{{ .File.Path }}' target="_blank">Suggest an edit</a> to this page on GitHub.
+<div class='suggest-an-edit'>
+    Spotted a mistake or got an idea on how to improve this page? <br />
+    <a href='https://github.com/ivpn/ivpn.net/tree/main/src/content/{{ .File.Path }}' target="_blank">
+        Suggest an edit</a> on GitHub.
 </div>


### PR DESCRIPTION
This PR adds "suggest an edit" section to the content pages footer
with the link to the correspondent markdown file on GitHub