### PR TITLE
Redirect for AntiTracker Hardcore Mode page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -321,5 +321,6 @@ server {
     rewrite ^/knowledgebase/android/android---disposable-emails/$ /knowledgebase/android/android-disposable-emails/ permanent;
     rewrite ^/knowledgebase/routers/dd-wrt---how-do-i-exclude-hosts-or-bypass-vpn-tunnel/$ /knowledgebase/routers/dd-wrt-how-do-i-exclude-hosts-or-bypass-vpn-tunnel/ permanent;
     rewrite ^/knowledgebase/routers/dd-wrt---tls-errors---incoming-plaintext-read-error-etc/$ /knowledgebase/routers/dd-wrt-tls-errors-incoming-plaintext-read-error-etc/ permanent;
+    rewrite ^/antitracker/hardcore$ /knowledgebase/general/antitracker-faq/ permanent;
 }
 


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other

## What is the new behavior?

Add a redirect for AntiTracker Hardcore Mode page that was not rebuilt for the new website:

https://www.ivpn.net/antitracker/hardcore  
->  
https://www.ivpn.net/knowledgebase/general/antitracker-faq/  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No