### PR TITLE
Exclude /updates/mac/sparkle/ from being index by google bot

### DIFF
--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /updates/
+
+User-agent: *
+Allow: /

--- a/src/static/robots.txt
+++ b/src/static/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Disallow: /updates/
+Disallow: /updates/mac/sparkle/
 
 User-agent: *
 Allow: /


### PR DESCRIPTION
This PR excludes /updates/mac/sparkle/ directory from being indexed by google bot. 
This folder contains few legacy .html files which are not designed to be opened by user / google.

We're not using Sparkle for the updates any longer, however, we do not want to remove these files now, as there might some older version of software update notification for which might break if we remove them. 