### PR TITLE
Update single.html

### DIFF
--- a/src/themes/ivpn-v3/layouts/blog/single.html
+++ b/src/themes/ivpn-v3/layouts/blog/single.html
@@ -34,7 +34,7 @@
 {{if gt (len .Params.tags) 0}}
     <section class="blog-article">
         {{ range .Params.tags }}
-            <a href="{{ printf "/blog/tags/%s/" (. | urlize) }}" class="tag tag--inline" rel="noindex, dofollow">{{ humanize . }}</a>
+            <a href="{{ printf "/blog/tags/%s/" (. | urlize) }}" class="tag tag--inline" rel="noindex, dofollow">{{ . }}</a>
         {{ end }}
     </section>
 {{ end }}


### PR DESCRIPTION
It seems that the `humanize` function messes up how tags are displayed when it is written in CamelCase, for example all "WireGuard" tags are displayed as "Wire guard" in the blog posts.

Example page (see on the very bottom):
https://www.ivpn.net/blog/windows-support-and-privacy-improvements-for-wireguard/

Since tags are already specified in the .md files capitalized, there is no need to do anything with them there.

## PR type
What kind of change does this PR introduce?

- [X] Bugfix
