### PR TITLE
fix: change overflow-x, display to block of table element

### DIFF
--- a/src/themes/ivpn-v3/assets/scss/elements/table.scss
+++ b/src/themes/ivpn-v3/assets/scss/elements/table.scss
@@ -1,6 +1,8 @@
 table {
     width: 100%;
     margin-bottom: 24px;
+    overflow-x: auto;
+    display: block;
 
     th {
         padding: 20px;


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number: #172 

When the viewport reached a width of approximately 485px or less, the table element would clip the right-most table column with no ability for the user to scroll. 

## What is the new behavior?

When the table element reaches 485px or less, the table will extend past the viewport with the ability for the user to scroll.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
