### PR TITLE
docs: add-installation-guide-to-README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [Security Policy](#security)
 * [License](#license)
 * [Authors](#authors)
+* [Installation Guide](#installation)
 
 <a name="about-repo"></a>
 ## About this Repo

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ See the [Authors](/AUTHORS) file for the list of contributors who participated i
 <a name="installation"></a>
 ## Installation Guide
 
-> This is a installation summary for running IVPN's static website locally.
+> This is an installation summary for running IVPN's static website locally.
 
 **Windows:**
 
-1. Install [Windows Subystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install)
+1. Install [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install)
 2. Upgrade [WSL to WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-4---download-the-linux-kernel-update-package)
 3. Change the Default Version of WSL to WSL 2
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See the [Authors](/AUTHORS) file for the list of contributors who participated i
 <a name="installation"></a>
 ## Installation Guide
 
-> This is a installation summary for running IVPN's static website locally on your system.
+> This is a installation summary for running IVPN's static website locally.
 
 **Windows:**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * [Contributing](#contributing)
 * [Security Policy](#security)
 * [License](#license)
-* [Authors](#Authors)
+* [Authors](#authors)
 
 <a name="about-repo"></a>
 ## About this Repo
@@ -30,3 +30,43 @@ This project is licensed under the GPLv3 - see the [License](/LICENSE.md) file f
 ## Authors
 
 See the [Authors](/AUTHORS) file for the list of contributors who participated in this project.
+
+<a name="installation"></a>
+## Installation Guide
+
+> This is a installation summary for running IVPN's static website locally on your system.
+
+**Windows:**
+
+1. Install [Windows Subystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install)
+2. Upgrade [WSL to WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-4---download-the-linux-kernel-update-package)
+3. Change the Default Version of WSL to WSL 2
+
+    ```
+    wsl --set-default-version 2
+    ```
+    
+4. Install [Docker](https://www.docker.com/) (Documentation: [https://docs.docker.com/](https://docs.docker.com/))
+5. Clone or Download the IVPN repository
+6. Open Powershell and cd to the previously downloaded repository and run the following commands:
+    ```
+    docker build -t website:latest --build-arg ENV=staging .
+    
+    docker run -it --publish 8010:80 website  
+    ```
+7. Open the website at [http://localhost:8010/](http://localhost:8010/)
+
+**M1 Mac:**
+
+1. Install Docker as well as its prerequisites for your system.
+2. Clone or Download the IVPN repository.
+3. Open Terminal and cd to the previously download repository and run the following commands:
+
+   
+    ```
+    docker buildx build --platform linux/amd64 -t website:latest --build-arg ENV=staging .
+  
+    docker run -it --publish 8010:80 website  
+    ```
+    
+4. Open the website at [http://localhost:8010/](http://localhost:8010/)


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

When viewing your CONTRIBUTING.md doc, it has a link to an installation guide in the README. However, this link just sends the user back to the README with no installation guide.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number: #215

## What is the new behavior?

This PR adds an installation guide for the Windows and Macintosh Operating systems (M1 Macs) that allows new open-source contributors to quickly install a locally run version of the website.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information

When adding the installation guide to the README, the 'authors' table of contents link would break. Changing it from (#Authors) to (#authors) solved this issue.

Resolves #215