### PR TITLE
refractor: footer links - column 4 - rel attribute

### DIFF
--- a/src/config/_default/config.toml
+++ b/src/config/_default/config.toml
@@ -202,26 +202,30 @@ disableKinds = ["sitemap", "taxonomyTerm"]
     identifier = "reddit"
     name = "Reddit"
     url = "https://www.reddit.com/r/IVPN/"
-    rel = "noopener noreferrer"
     weight = 20
+    [menu.footercolfour.params]
+      rel = "noopener"
 
   [[menu.footercolfour]]
     identifier = "twitter"
     name = "Twitter"
     url = "https://twitter.com/ivpnnet"
-    rel = "noopener noreferrer"
     weight = 30
+    [menu.footercolfour.params]
+      rel = "noopener"
 
   [[menu.footercolfour]]
     identifier = "github"
     name = "GitHub"
     url = "https://github.com/ivpn"
-    rel = "noopener noreferrer"
     weight = 40
+    [menu.footercolfour.params]
+      rel = "noopener"
   
   [[menu.footercolfour]]
     identifier = "mastodon"
     name = "Mastodon"
     url = "https://mastodon.social/@ivpn"
-    rel = "noopener noreferrer me"
     weight = 50
+    [menu.footercolfour.params]
+      rel = "noopener me"

--- a/src/config/_default/config.toml
+++ b/src/config/_default/config.toml
@@ -202,22 +202,26 @@ disableKinds = ["sitemap", "taxonomyTerm"]
     identifier = "reddit"
     name = "Reddit"
     url = "https://www.reddit.com/r/IVPN/"
+    rel = "noopener"
     weight = 20
 
   [[menu.footercolfour]]
     identifier = "twitter"
     name = "Twitter"
     url = "https://twitter.com/ivpnnet"
+    rel = "noopener"
     weight = 30
 
   [[menu.footercolfour]]
     identifier = "github"
     name = "GitHub"
     url = "https://github.com/ivpn"
+    rel = "noopener"
     weight = 40
   
   [[menu.footercolfour]]
     identifier = "mastodon"
     name = "Mastodon"
     url = "https://mastodon.social/@ivpn"
+    rel = "noopener"
     weight = 50

--- a/src/config/_default/config.toml
+++ b/src/config/_default/config.toml
@@ -202,26 +202,26 @@ disableKinds = ["sitemap", "taxonomyTerm"]
     identifier = "reddit"
     name = "Reddit"
     url = "https://www.reddit.com/r/IVPN/"
-    rel = "noopener"
+    rel = "noopener noreferrer"
     weight = 20
 
   [[menu.footercolfour]]
     identifier = "twitter"
     name = "Twitter"
     url = "https://twitter.com/ivpnnet"
-    rel = "noopener"
+    rel = "noopener noreferrer"
     weight = 30
 
   [[menu.footercolfour]]
     identifier = "github"
     name = "GitHub"
     url = "https://github.com/ivpn"
-    rel = "noopener"
+    rel = "noopener noreferrer"
     weight = 40
   
   [[menu.footercolfour]]
     identifier = "mastodon"
     name = "Mastodon"
     url = "https://mastodon.social/@ivpn"
-    rel = "noopener me"
+    rel = "noopener noreferrer me"
     weight = 50

--- a/src/config/_default/config.toml
+++ b/src/config/_default/config.toml
@@ -223,5 +223,5 @@ disableKinds = ["sitemap", "taxonomyTerm"]
     identifier = "mastodon"
     name = "Mastodon"
     url = "https://mastodon.social/@ivpn"
-    rel = "noopener"
+    rel = "noopener me"
     weight = 50

--- a/src/themes/ivpn-v3/layouts/partials/footer.html
+++ b/src/themes/ivpn-v3/layouts/partials/footer.html
@@ -38,7 +38,7 @@
                 {{ range .Site.Menus.footercolfour }}
                 <li>
                     <img width="24" height="25" src="{{ site.Params.cdnUrl }}/images/{{ .Identifier }}.svg" /><a
-                        href="{{ .URL }}" {{ with .Rel }}rel="{{ . }}"{{ end }}>{{ .Name }}</a>
+                        href="{{ .URL }}" {{ with .Params.rel }}rel="{{ . }}"{{ end }}>{{ .Name }}</a>
                 </li>
                 {{ end }}
             </ul>

--- a/src/themes/ivpn-v3/layouts/partials/footer.html
+++ b/src/themes/ivpn-v3/layouts/partials/footer.html
@@ -38,7 +38,7 @@
                 {{ range .Site.Menus.footercolfour }}
                 <li>
                     <img width="24" height="25" src="{{ site.Params.cdnUrl }}/images/{{ .Identifier }}.svg" /><a
-                        href="{{ .URL }}">{{ .Name }}</a>
+                        href="{{ .URL }}" {{ with .Rel }}rel="{{ . }}"{{ end }}>{{ .Name }}</a>
                 </li>
                 {{ end }}
             </ul>


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

*Unsure if this requires configuration usage documentation.*

## What is the current behavior?

Currently iVPN has a link to mastodon but it lacks `rel="me"`, meaning iVPN does not appear verified on Mastodon.

The iVPN site also does not include noopener or noferrer on external social links.

The changes detailed in the next section allow the `rel` to be customized within `config.toml`, allowing these problems to be addressed individually.

## What is the new behavior?

Now `footercolfour` links in the `config.toml` can be configured to have a `rel`. If one does not exist, it will not add the `rel` definition at all. This accomplishes three tasks:

+ Allows external links to be configured with [noopener](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noopener), preventing [tabnapping](https://wikipedia.org/wiki/Tabnabbing).
+ Allows verified links with services such as Mastodon.
+ Allows adding [noreferrer](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noreferrer), optionally, this is intentionally the last commit so it can be easily chopped off.

Note in the `config.toml` file the `mastodon` definition includes `me` . iVPN already includes the proper link (without the `me`) on their site, but their Mastodon profile lacks verification. This modification would allow the site to automatically become verified on Mastodon with no further effort. Relevant links for this:

+ https://joinmastodon.org/verification
+ https://mastodon.social/settings/verification

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
