### PR TITLE
task: Remove the wireguard private key in the BTC invoice metadata

### DIFF
--- a/src/themes/ivpn-v3/assets/js/api/api.js
+++ b/src/themes/ivpn-v3/assets/js/api/api.js
@@ -413,7 +413,6 @@ export default {
         }
         let response = await this.Post('/web/accounts/btc/create-light-invoice', {
             price_id: priceID,
-            private_key: privateKey,
             public_key: publicKey,
             exit_server: exitServer,
             entry_server: entryServer 


### PR DESCRIPTION

## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

When submiting a request to the API endpoint /web/accounts/btc/create-light-invoice, the client side generated Wireguard private key is also sent to the invoice metadata.

Issue number: #842

## What is the new behavior?

The Wireguard private key has been removed from the request since only the public key is required for the account provisioning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
