### PR TITLE
Modify LAN IP addresses in WireGuard setup guide

### DIFF
--- a/src/content/en/pages/setup/router/mikrotik-wireguard.md
+++ b/src/content/en/pages/setup/router/mikrotik-wireguard.md
@@ -58,8 +58,8 @@ WireGuard config file generator is only available for accounts that were created
 
 2. Navigate to `Routing` - `Rules`, click `+` to allow communication between devices on your LAN — including access to the router itself:
 
-    * Src. Address - the IP address of your local network, e.g., **10.0.0.0/24**
-    * Dst. Address - **10.0.0.0/24**
+    * Src. Address - the IP address of your LAN network, e.g., **192.168.88.0/24**
+    * Dst. Address - **192.168.88.0/24**
     * Action - **lookup**
     * Table - **main**
 


### PR DESCRIPTION
Updated the source and destination addresses for LAN communication in the Mikrotik WireGuard setup instructions.

## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number: N/A

## What is the new behavior?
The configuration starts working. Using 10.x network addr everywhere is misleading and causes errors later in NAT section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
